### PR TITLE
Avoids force unwrap in stream cancellation

### DIFF
--- a/lib/keyboard_height_plugin.dart
+++ b/lib/keyboard_height_plugin.dart
@@ -4,25 +4,21 @@ import 'package:flutter/services.dart';
 typedef KeyboardHeightCallback = void Function(double height);
 
 class KeyboardHeightPlugin {
-    static const EventChannel _keyboardHeightEventChannel = EventChannel('keyboardHeightEventChannel');
+  static const EventChannel _keyboardHeightEventChannel =
+      EventChannel('keyboardHeightEventChannel');
 
-    StreamSubscription? _keyboardHeightSubscription;
+  StreamSubscription? _keyboardHeightSubscription;
 
-
-    void onKeyboardHeightChanged(KeyboardHeightCallback callback) {
-        if (_keyboardHeightSubscription != null) {
-            _keyboardHeightSubscription!.cancel();
-        }
-        _keyboardHeightSubscription = _keyboardHeightEventChannel
+  void onKeyboardHeightChanged(KeyboardHeightCallback callback) {
+    _keyboardHeightSubscription?.cancel();
+    _keyboardHeightSubscription = _keyboardHeightEventChannel
         .receiveBroadcastStream()
         .listen((dynamic height) {
-            callback(height as double);
-        });
-    }
+      callback(height as double);
+    });
+  }
 
-    void dispose() {
-        if (_keyboardHeightSubscription != null) {
-            _keyboardHeightSubscription!.cancel();
-        }
-    }
+  void dispose() {
+    _keyboardHeightSubscription?.cancel();
+  }
 }


### PR DESCRIPTION
Small style improvement:
Avoids the `(_keyboardHeightSubscription != null)` check in the plugin and instead just uses the optional chaining `?.` on the stream subscription object.