### PR TITLE
Use WindowInsetsCompat for navigation bar height

### DIFF
--- a/android/src/main/kotlin/com/nschairer/keyboard_height_plugin/KeyboardHeightPlugin.kt
+++ b/android/src/main/kotlin/com/nschairer/keyboard_height_plugin/KeyboardHeightPlugin.kt
@@ -8,6 +8,8 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class KeyboardHeightPlugin : FlutterPlugin, EventChannel.StreamHandler, ActivityAware {
     private val keyboardHeightEventChannelName = "keyboardHeightEventChannel"
@@ -33,15 +35,20 @@ class KeyboardHeightPlugin : FlutterPlugin, EventChannel.StreamHandler, Activity
                 rootView.getWindowVisibleDisplayFrame(r)
 
                 val screenHeight = rootView.height
-                val navigationBarHeight = getNavigationBarHeight();
+                val insets = ViewCompat.getRootWindowInsets(rootView)
+                val navigationBarHeight = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0;
+                val isNavigationBarVisible = insets?.isVisible(WindowInsetsCompat.Type.navigationBars()) ?: false
+                
                 var keypadHeight = screenHeight - r.bottom
-                if (isNavigationBarVisible()) {
+                
+                if (isNavigationBarVisible) {
                     keypadHeight -= navigationBarHeight
                 }
+
                 val displayMetrics = activityPluginBinding?.activity?.resources?.displayMetrics
                 val logicalKeypadHeight = keypadHeight / (displayMetrics?.density ?: 1f)
 
-                if (keypadHeight > screenHeight * 0.15) {
+                if (keypadHeight > screenHeight * 0.02) {
                     events?.success(logicalKeypadHeight.toDouble())
                 } else {
                     events?.success(0.0)
@@ -54,26 +61,6 @@ class KeyboardHeightPlugin : FlutterPlugin, EventChannel.StreamHandler, Activity
         eventSink = null
     }
 
-    private fun getNavigationBarHeight(): Int {
-        val resourceId = activityPluginBinding?.activity?.resources?.getIdentifier("navigation_bar_height", "dimen", "android")
-        return if (resourceId != null && resourceId > 0) {
-            activityPluginBinding?.activity?.resources?.getDimensionPixelSize(resourceId) ?: 0
-        } else {
-            0
-        }
-    }
-
-    private fun isNavigationBarVisible(): Boolean {
-        val decorView = activityPluginBinding?.activity?.window?.decorView
-        val rootWindowInsets = decorView?.rootWindowInsets ?: return false
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            rootWindowInsets.isVisible(android.view.WindowInsets.Type.navigationBars())
-        } else {
-            val systemWindowInsetBottom = rootWindowInsets.systemWindowInsetBottom
-            systemWindowInsetBottom > 0
-        }
-    }
-    
     // Implement ActivityAware methods
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activityPluginBinding = binding


### PR DESCRIPTION
`getNavigationBarHeight()` and `isNavigationBarVisible()` can return incorrect values on some devices in gesture navigation mode, leading to wrong keyboard height calculation

On the Huawei v40 lite I have:

- Gesture navigation + indicator bar disabled
    - Original code: height = 38, visible = true
    - Correct values: height = 0, visible = false

- Gesture navigation + indicator bar enabled
    - Original code: height = 16
    - Correct value: height = 38

- Button navigation
    - Original code returns the correct height of 38

I propose switching to WindowInsetsCompat to retrieve the navigation bar height:

```
val insets = ViewCompat.getRootWindowInsets(rootView)
val navigationBarHeight = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
val isNavigationBarVisible = insets?.isVisible(WindowInsetsCompat.Type.navigationBars()) ?: false
```

This returns the correct values on all devices I tested (Huawei V40 Lite, Redmi K70, Samsung S9)

This may also fix #11
